### PR TITLE
Testing "minimal mistakes" with remote theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "github-pages", group: :jekyll_plugins
+gem "jekyll-include-cache"

--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ Get docker at https://docs.docker.com/
 For some fields you'll need a personal access token from github. See how to get it [here](
 https://github.com/jekyll/github-metadata/blob/master/docs/authentication.md).
 To use it run the docker container with the following option `-e JEKYLL_GITHUB_TOKEN=****`
+
+`docker pull jekyll/jekyll:3.8`
+
+`docker run --rm --volume="c:\path\open-simulation-platform.github.io:/srv/jekyll" -e JEKYLL_GITHUB_TOKEN=*************** -p 4000:4000 -it jekyll/jekyll:3.8 bash -c "bundle update && bundle install && bundle exec jekyll serve -H 0.0.0.0"`

--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,11 @@
-theme: jekyll-theme-slate
+remote_theme: "mmistakes/minimal-mistakes@4.19.1"
+minimal_mistakes_skin: "air" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum" "sunrise"
 repository: open-simulation-platform/cse-core
 title: "Core Simulation Environment"
 description: "co-simulation software"
 
 plugins:
+  - jekyll-include-cache
   - jekyll-github-metadata
   - jekyll-mentions
   - jekyll-redirect-from

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,0 +1,5 @@
+main:
+  - title: "CSE"
+    url: /cse-core/cse/
+  - title: "demo app"
+    url: /cse-demo-app/cse-demo-app/

--- a/index.md
+++ b/index.md
@@ -1,5 +1,6 @@
 ---
-layout: default
+layout: splash
+classes: landing
 title: "CSE"
 permalink: /
 ---


### PR DESCRIPTION
I would like to test a different theme that has navigation components as navigation bar and sidebar. With this PR I try do to as little as possible to first check that you are able to run this locally and that it works when deploying.

I'll introduce more changes to fix the layout once we have successfully tested that this works.

I couldn't get `starefossen/github-pages` to work with remote themes so you'll have to pull a jekyll image: `docker pull jekyll/jekyll:3.8`

Use the following command to test locally:
`docker run --rm --volume="c:\path\open-simulation-platform.github.io:/srv/jekyll" -e JEKYLL_GITHUB_TOKEN=*************** -p 4000:4000 -it jekyll/jekyll:3.8 bash -c "bundle update && bundle install && bundle exec jekyll serve -H 0.0.0.0"`

You should see "CSE" and "demo app" as links to the top right.

