### PR TITLE
Update cosim4j information

### DIFF
--- a/cosim4j.md
+++ b/cosim4j.md
@@ -16,31 +16,3 @@ nav_order: 4
 The Java wrapper `cosim4j` enables Java applications to make use of `libcosim`.
 It uses the Java Native Interface (JNI) to efficiently interact with `libcosim`. 
 To make it accessible, all native dependencies for Linux and Windows have been pre-built and are bundled with the library.
-
-A highly convenient and powerful feature found in `cosim4j`
-is the ability to write inline FMI 2.0 compatible models
-using Java, i.e., models can be written as regular Java
-code that can be added directly to the simulation without first
-exporting them as FMUs. However, if required - for instance,
-in order to run the same model in another FMI/SSP compliant
-tool - the model can be exported as it is. This is possible thanks
-to deep integration with [FMI4j](https://github.com/NTNU-IHB/FMI4j){:target="_blank"}, a software package for
-dealing with FMUs on the JVM.
- 
-The code below shows the minimal required to write FMI 2.0 compatible models in Java using FMI4j.
-
-```java
-public class JavaSlave extends Fmi2Slave {
-
-    @ScalarVariable (causality=Fmi2Causality.output)
-    private double realOutput;
-
-    public JavaSlave(Map<String, Object> args) {
-        super(args);
-    }
-
-    public void doStep(double t, double dt) {
-        realOutput= ...
-    }
-}
-```


### PR DESCRIPTION
Java slaves have been removed from cosim4j. This update reflects that. Export normal FMUs using FMI4j instead.