### PR TITLE
Update Kopl download links

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -16,5 +16,5 @@ You can use this page to download:
 - [cosim4j (java wrapper)](https://github.com/open-simulation-platform/cosim4j/releases){:target="_blank"}
 - [demo simulation models](https://github.com/open-simulation-platform/demo-cases/releases){:target="_blank"}
 - [osp-validator](https://github.com/open-simulation-platform/osp-validator/releases){:target="_blank"}
-- [Kopl - windows](https://simapublicfiles.blob.core.windows.net/kopl/kopl-1.0.2-win32.x86_64.zip)
-- [Kopl - linux (experimental)](https://simapublicfiles.blob.core.windows.net/kopl/kopl-1.0.2-linux.gtk.x86_64.zip)
+- [Kopl - windows](https://simapublicfiles.blob.core.windows.net/kopl/kopl-2.0.0.win32.x86_64.zip)
+- [Kopl - linux (experimental)](https://simapublicfiles.blob.core.windows.net/kopl/kopl-2.0.0-linux.gtk.x86_64.zip)

--- a/kopl.md
+++ b/kopl.md
@@ -7,7 +7,7 @@ nav_order: 7
 ---
 
 # Configuration tool
-`Kopl` is a configurator to help set up and run a simulation. It can also be used to validate the model using the [OSP validator](./osp-validator). 
+`Kopl` is a configurator to help set up and run a simulation. 
 `Kopl` is not an open source software but can be freely used without any restrictions.
 
 {% include figure.html 
@@ -53,10 +53,6 @@ Just start dragging from an output or input slot and drop when hovering over the
     num="2" 
     caption="Definition of nested variable groups" 
 %}
-
-## OSP-IS validation
-
-Right click the configuration and choose validate in the context menu to let the [OSP validator](./osp-validator) validate the current setup
 
 ## Export
 


### PR DESCRIPTION
A new version of Kopl is available, running on the latest cosim-cli. OSP-validator has been de-integrated and removed from documentation.